### PR TITLE
Added missing semicolon to package example

### DIFF
--- a/source/std/experimental/xml/package.d
+++ b/source/std/experimental/xml/package.d
@@ -92,7 +92,7 @@
 +           assert(0, "Missing XML declaration");
 +       else
 +           assert(0, "Invalid attributes syntax");
-+   }
++   };
 +
 +   // used by checkXMLNames, a pluggable validator
 +   auto callback2 = (string s) { assert(0, "Invalid XML element name"); }


### PR DESCRIPTION
The examples should be documentation unittests.
