### PR TITLE
Support foreach on std.experimental.xml.dom.NodeList

### DIFF
--- a/source/std/experimental/xml/dom.d
+++ b/source/std/experimental/xml/dom.d
@@ -700,6 +700,12 @@ interface NodeList(DOMString)
     +   `0` to `length-1` inclusive.
     +/
     @property size_t length();
+    ///
+    bool empty();
+    ///
+    void popFront();
+    ///
+    Node!DOMString front();
 }
 
 /++

--- a/source/std/experimental/xml/domimpl.d
+++ b/source/std/experimental/xml/domimpl.d
@@ -533,16 +533,16 @@ class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = b
                     }
                     return result;
                 }
+                // range interface
+                Node front() { return currentChild; }
+                void popFront() { currentChild = currentChild.nextSibling; }
+                bool empty() { return currentChild is null; }
             }
             // more idiomatic methods
             auto opIndex(size_t i)
             {
                 return item(i);
             }
-            // range interface
-            auto front() { return currentChild; }
-            void popFront() { currentChild = currentChild.nextSibling; }
-            bool empty() { return currentChild is null; }
         }
         // method not required by the spec, specialized in NodeWithChildren
         bool isAncestor(Node other) { return false; }
@@ -1167,14 +1167,13 @@ class DOMImplementation(DOMString, Alloc = shared(GCAllocator), ErrorHandler = b
                 }
                 return res;
             }
+            // range interface
+            bool empty() { return current is null; }
+            void popFront() { current = findNext(current); }
+            Element front() { return current; }
         }
         // more idiomatic methods
         auto opIndex(size_t i) { return item(i); }
-
-        // range interface
-        bool empty() { return current is null; }
-        void popFront() { current = findNext(current); }
-        auto front() { return current; }
     }
     /// Implementation of $(LINK2 ../dom/CharacterData, `std.experimental.xml.dom.CharacterData`)
     abstract class CharacterData: Node, dom.CharacterData!DOMString


### PR DESCRIPTION
I want to write helper function like,

```
int delegate(int delegate(ref Element!string)) elementsNamed(Node!string node, string elemName)
{
    ...
    foreach (n; node.childNodes) { ... }
    ...
}
```

To make `NodeList` foreach-able, I added `empty`, `popFront` and `front` like subclasses.
How do you think about this?
