### PR TITLE
Fix it so that NodeType can be used when importing package.

### DIFF
--- a/source/std/experimental/xml/package.d
+++ b/source/std/experimental/xml/package.d
@@ -253,12 +253,11 @@ public import std.experimental.xml.parser;
 public import std.experimental.xml.cursor;
 public import std.experimental.xml.validation;
 public import std.experimental.xml.writer;
+public import std.experimental.xml.dom;
 public import std.experimental.xml.domparser;
 public import std.experimental.xml.domimpl;
 public import std.experimental.xml.sax;
 public import std.experimental.xml.faststrings;
-
-public import dom = std.experimental.xml.dom;
 
 @nogc unittest
 {


### PR DESCRIPTION
With the way the import was done previously, if code imported std.xml
and it tried to use NodeType, it got an error about it being undefined.

I don't know why the import for the dom module was different from all of the others, and there may be a good reason for it that makes this change a bad idea, but as the code was, using NodeType did result in an error.

On a related note, as far as improvements go, it would be nice to have a way to indicate that you want all comments stripped from your parse results. I ran into this problem with NodeType, because I was having to check for comments so that I could ignore them rather than giving an error when an XML document had a tag in it that it wasn't supposed to.

One improvement that I was _very_ glad to see though was that it's no longer required to create the the DomBuilder and then separately set the source type. It's much nicer to be able to just do it all in one line:

    auto domBuilder = lexer(xml).parser().cursor().domBuilder();

Though I confess that upon seeing something like this, I tend to think that it should be possible to do something like

    auto domBuilder = xml.domBuilder();

and have the domBuilder function do all of the rest. The full version is likely useful to have in some circumstances such that the whole chain should still be possible, but it does seem awfully verbose if what you want is to basically just parse the XML and get the result.